### PR TITLE
Update mitmproxy image to be pinned to latest 2.x release

### DIFF
--- a/docker/mitmproxy/mitmproxy.go
+++ b/docker/mitmproxy/mitmproxy.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	MITMProxyImageName          = "mitmproxy/mitmproxy"
+	MITMProxyImageName          = "mitmproxy/mitmproxy:2.0.2"
 	MITMProxyPort               = 8080
 	MITMProxyPrefix             = "mitm"
 	MITMProxyDefaultCADirectory = "/home/mitmproxy/.mitmproxy"


### PR DESCRIPTION
Fixes #1

The `latest` (a `3.x` version at the moment) deprecates a flag that the mitmproxy runner uses. Until that gets fixed, the version of mitmproxy needs to be fixed on a 2.x branch.